### PR TITLE
[CLIPY-38] 도메인 모델 정의

### DIFF
--- a/app/src/test/java/com/laxotters/clipy/ExampleUnitTest.kt
+++ b/app/src/test/java/com/laxotters/clipy/ExampleUnitTest.kt
@@ -1,7 +1,7 @@
 package com.laxotters.clipy
 
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
+import org.junit.Assert.assertEquals
+import org.junit.Test
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/build-logic/src/main/kotlin/convention/TestKotlin.kt
+++ b/build-logic/src/main/kotlin/convention/TestKotlin.kt
@@ -1,19 +1,12 @@
 package convention
 
 import org.gradle.api.Project
-import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.withType
 
 internal fun Project.configureTest() {
     val libs = extensions.libs
 
-    tasks.withType<Test>().configureEach {
-        useJUnitPlatform()
-    }
-
     dependencies {
-        add("testImplementation", libs.findLibrary("junit-jupiter").get())
-        add("testRuntimeOnly", libs.findLibrary("junit-platform-launcher").get())
+        add("testImplementation", libs.findLibrary("junit").get())
     }
 }

--- a/domain/src/main/java/com/laxotters/clipy/domain/model/Capture.kt
+++ b/domain/src/main/java/com/laxotters/clipy/domain/model/Capture.kt
@@ -1,0 +1,12 @@
+package com.laxotters.clipy.domain.model
+
+import java.time.Instant
+import java.util.UUID
+
+data class Capture(
+    val id: UUID,
+    val itemId: UUID,
+    val imageRef: ImageRef,
+    val capturedAt: Instant,
+    val memo: String?,
+)

--- a/domain/src/main/java/com/laxotters/clipy/domain/model/Clipy.kt
+++ b/domain/src/main/java/com/laxotters/clipy/domain/model/Clipy.kt
@@ -1,3 +1,0 @@
-package com.laxotters.clipy.domain.model
-
-data class Clipy(val id: String)

--- a/domain/src/main/java/com/laxotters/clipy/domain/model/Decision.kt
+++ b/domain/src/main/java/com/laxotters/clipy/domain/model/Decision.kt
@@ -1,0 +1,11 @@
+package com.laxotters.clipy.domain.model
+
+import java.time.Instant
+import java.util.UUID
+
+data class Decision(
+    val id: UUID,
+    val sessionId: UUID,
+    val itemId: UUID,
+    val decidedAt: Instant,
+)

--- a/domain/src/main/java/com/laxotters/clipy/domain/model/ImageRef.kt
+++ b/domain/src/main/java/com/laxotters/clipy/domain/model/ImageRef.kt
@@ -1,0 +1,6 @@
+package com.laxotters.clipy.domain.model
+
+data class ImageRef(
+    val remoteUrl: String,
+    val localPath: String?,
+)

--- a/domain/src/main/java/com/laxotters/clipy/domain/model/Item.kt
+++ b/domain/src/main/java/com/laxotters/clipy/domain/model/Item.kt
@@ -1,0 +1,24 @@
+package com.laxotters.clipy.domain.model
+
+import java.time.Instant
+import java.util.UUID
+
+enum class ItemIntentState {
+    INTERESTED,
+    HOLD,
+    DROPPED,
+}
+
+data class Item(
+    val id: UUID,
+    val sessionId: UUID,
+    val sourceUrl: String,
+    val productName: String?,
+    val priceSnapshot: MoneySnapshot?,
+    val thumbnailImage: ImageRef?,
+    val note: String?,
+    val intentState: ItemIntentState,
+    val captures: List<Capture>,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+)

--- a/domain/src/main/java/com/laxotters/clipy/domain/model/MoneySnapshot.kt
+++ b/domain/src/main/java/com/laxotters/clipy/domain/model/MoneySnapshot.kt
@@ -1,0 +1,7 @@
+package com.laxotters.clipy.domain.model
+
+data class MoneySnapshot(
+    val amount: Long,
+    val currency: String,
+    val rawText: String?,
+)

--- a/domain/src/main/java/com/laxotters/clipy/domain/model/Session.kt
+++ b/domain/src/main/java/com/laxotters/clipy/domain/model/Session.kt
@@ -1,0 +1,24 @@
+package com.laxotters.clipy.domain.model
+
+import java.time.Instant
+import java.util.UUID
+
+enum class SessionStatus {
+    DRAFT,
+    COLLECTING,
+    PENDING,
+    DECIDED,
+    ABANDONED,
+}
+
+data class Session(
+    val id: UUID,
+    val name: String?,
+    val status: SessionStatus,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+    val closedAt: Instant?,
+    val abandonedAt: Instant?,
+    val items: List<Item>,
+    val decisions: List<Decision>,
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ room = "2.8.4"
 coil = "2.7.0"
 
 # Testing
-junit5 = "6.0.3"
+junit4 = "4.13.2"
 androidxJunit = "1.3.0"
 espressoCore = "3.7.0"
 
@@ -102,8 +102,7 @@ androidx-room-testing = { group = "androidx.room", name = "room-testing", versio
 inject = "javax.inject:javax.inject:1"
 
 # Testing
-junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit5" }
-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit5" }
+junit = { group = "junit", name = "junit", version.ref = "junit4" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJunit" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 


### PR DESCRIPTION
## 📋 개요
> Closes #6
> Jira: CLIPY-38

- Session 기반 저장/복원 작업의 기준이 될 domain model baseline을 추가했습니다.

## 변경 배경

- 이후 Room DB schema와 ViewState 저장 구조가 이 모델을 기준으로 분리 구현될 수 있도록 먼저 공통 domain 모델을 정리했습니다.

## 변경 내용

- Domain entity / value object
  - `Session`, `Item`, `Capture`, `Decision` 모델을 추가했습니다.
  - `MoneySnapshot`, `ImageRef` value object를 추가했습니다.
  - `SessionStatus`, `ItemIntentState` 상태 값을 추가했습니다.

- 타입 기준 정리
  - id 계열은 `UUID`로 관리하도록 정리했습니다.
  - 날짜/시각 필드는 `Instant`를 사용했습니다.
  - 금액은 `Long`, 통화는 `String`으로 관리합니다.

- 테스트 설정
  - JVM unit test 기본 설정을 JUnit4 기준으로 정리했습니다.

## 구현 메모

- `SessionViewState`, 화면 복원 상태는 후속 작업에서 다룹니다.
- domain model에 생성 factory는 두지 않았습니다. 실제 세션 생성 흐름이 구현될 때 추가 여부를 판단합니다.

## 검증

<!-- 실행한 검증만 체크합니다. 실행하지 못한 항목은 이유를 적습니다. -->

- [x] `./gradlew test`
- [x] `./gradlew detekt ktlintCheck`

## 문서

- 변경 없음

## 실행 화면

- 없음

## 참고자료

- 없음