### PR TITLE
[CLIPY-45] BottomSheet 컴포넌트 구현

### DIFF
--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -6,3 +6,7 @@ plugins {
 }
 
 setNamespace("core.designsystem")
+
+dependencies {
+    testImplementation(libs.junit)
+}

--- a/core/designsystem/src/main/java/com/laxotters/clipy/core/designsystem/component/BottomSheet.kt
+++ b/core/designsystem/src/main/java/com/laxotters/clipy/core/designsystem/component/BottomSheet.kt
@@ -1,0 +1,269 @@
+package com.laxotters.clipy.core.designsystem.component
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import com.laxotters.clipy.core.designsystem.theme.ClipyTheme
+import kotlin.math.roundToInt
+
+@Composable
+fun ClipyBottomSheetLayout(
+    value: ClipyBottomSheetValue,
+    modifier: Modifier = Modifier,
+    headerContent: @Composable ColumnScope.(ClipyBottomSheetValue) -> Unit = {},
+    sheetContent: @Composable ColumnScope.(ClipyBottomSheetValue) -> Unit,
+) {
+    var layoutHeightPx by remember { mutableFloatStateOf(0f) }
+    val policy = rememberClipyBottomSheetPolicy(layoutHeightPx)
+    val offsetY = policy.offsetFor(value)
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .onSizeChanged { size ->
+                layoutHeightPx = size.height.toFloat()
+            },
+    ) {
+        if (layoutHeightPx > 0f) {
+            ClipyBottomSheetSurface(
+                value = value,
+                offsetY = offsetY,
+                hiddenOffset = policy.offsetFor(ClipyBottomSheetValue.HIDDEN),
+                headerContent = headerContent,
+                sheetContent = sheetContent,
+            )
+        }
+    }
+}
+
+@Composable
+private fun rememberClipyBottomSheetPolicy(
+    availableHeight: Float,
+): ClipyBottomSheetPolicy {
+    val density = LocalDensity.current
+    return with(density) {
+        remember(density, availableHeight) {
+            val expanded = 0f
+            val hidden = (availableHeight - ClipyBottomSheetDefaults.HiddenHeight.toPx())
+                .coerceAtLeast(expanded)
+            ClipyBottomSheetPolicy(
+                anchors = ClipyBottomSheetAnchors(
+                    expanded = expanded,
+                    peek = (availableHeight - ClipyBottomSheetDefaults.PeekHeight.toPx())
+                        .coerceIn(expanded, hidden),
+                    minimized = (availableHeight - ClipyBottomSheetDefaults.MinimizedHeight.toPx())
+                        .coerceIn(expanded, hidden),
+                    hidden = hidden,
+                ),
+                velocityThreshold = ClipyBottomSheetDefaults.VelocityThreshold.toPx(),
+                retentionBand = ClipyBottomSheetDefaults.RetentionBand.toPx(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ClipyBottomSheetSurface(
+    value: ClipyBottomSheetValue,
+    offsetY: Float,
+    hiddenOffset: Float,
+    modifier: Modifier = Modifier,
+    headerContent: @Composable ColumnScope.(ClipyBottomSheetValue) -> Unit,
+    sheetContent: @Composable ColumnScope.(ClipyBottomSheetValue) -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .offsetY(offsetY)
+            .shadow(
+                elevation = ClipyBottomSheetDefaults.SheetElevation,
+                shape = ClipyBottomSheetDefaults.SheetShape,
+                clip = false,
+            )
+            .background(
+                color = MaterialTheme.colorScheme.surface,
+                shape = ClipyBottomSheetDefaults.SheetShape,
+            ),
+    ) {
+        if (value != ClipyBottomSheetValue.HIDDEN) {
+            ClipyBottomSheetHandle()
+        }
+        headerContent(value)
+        ClipyBottomSheetAnimatedContent(
+            valueForContent = value,
+            sheetContent = sheetContent,
+        )
+        ClipyBottomSheetBottomSpacer(
+            hiddenOffset = hiddenOffset,
+            offsetY = offsetY,
+        )
+    }
+}
+
+@Composable
+private fun ClipyBottomSheetAnimatedContent(
+    valueForContent: ClipyBottomSheetValue,
+    modifier: Modifier = Modifier,
+    sheetContent: @Composable ColumnScope.(ClipyBottomSheetValue) -> Unit,
+) {
+    AnimatedContent(
+        targetState = valueForContent,
+        modifier = modifier,
+        transitionSpec = {
+            fadeIn(
+                animationSpec = tween(ClipyBottomSheetDefaults.CONTENT_FADE_IN_MILLIS),
+            ) togetherWith
+                fadeOut(animationSpec = tween(ClipyBottomSheetDefaults.CONTENT_FADE_OUT_MILLIS))
+        },
+        label = "ClipyBottomSheetContent",
+    ) { contentTargetValue ->
+        Column {
+            if (contentTargetValue != ClipyBottomSheetValue.HIDDEN) {
+                sheetContent(contentTargetValue)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ClipyBottomSheetBottomSpacer(
+    hiddenOffset: Float,
+    offsetY: Float,
+    modifier: Modifier = Modifier,
+) {
+    Spacer(
+        modifier = modifier.height(
+            with(LocalDensity.current) {
+                (hiddenOffset - offsetY)
+                    .coerceAtLeast(0f)
+                    .toDp()
+            },
+        ),
+    )
+}
+
+@Composable
+private fun ClipyBottomSheetHandle() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(ClipyBottomSheetDefaults.HandleHeight)
+            .padding(top = 12.dp),
+        contentAlignment = Alignment.TopCenter,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(
+                    width = ClipyBottomSheetDefaults.HandleWidth,
+                    height = ClipyBottomSheetDefaults.HandleIndicatorHeight,
+                )
+                .background(
+                    color = ClipyBottomSheetDefaults.HandleColor,
+                    shape = RoundedCornerShape(50),
+                ),
+        )
+    }
+}
+
+private fun Modifier.offsetY(offset: Float): Modifier =
+    this.then(
+        Modifier.offset {
+            IntOffset(
+                x = 0,
+                y = offset.roundToInt(),
+            )
+        },
+    )
+
+@Preview(showBackground = true)
+@Composable
+private fun ClipyBottomSheetHiddenPreview() {
+    ClipyBottomSheetPreviewContent(value = ClipyBottomSheetValue.HIDDEN)
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ClipyBottomSheetMinimizedPreview() {
+    ClipyBottomSheetPreviewContent(value = ClipyBottomSheetValue.MINIMIZED)
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ClipyBottomSheetPeekPreview() {
+    ClipyBottomSheetPreviewContent(value = ClipyBottomSheetValue.PEEK)
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ClipyBottomSheetExpandedPreview() {
+    ClipyBottomSheetPreviewContent(value = ClipyBottomSheetValue.EXPANDED)
+}
+
+@Composable
+private fun ClipyBottomSheetPreviewContent(value: ClipyBottomSheetValue) {
+    ClipyTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+        ) {
+            ClipyBottomSheetLayout(
+                value = value,
+                sheetContent = { targetValue ->
+                    ClipyBottomSheetPreviewSheetContent(value = targetValue)
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ClipyBottomSheetPreviewSheetContent(value: ClipyBottomSheetValue) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(
+                when (value) {
+                    ClipyBottomSheetValue.HIDDEN -> 0.dp
+                    ClipyBottomSheetValue.MINIMIZED -> 88.dp
+                    ClipyBottomSheetValue.PEEK -> 254.dp
+                    ClipyBottomSheetValue.EXPANDED -> 360.dp
+                },
+            )
+            .padding(horizontal = 20.dp),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        androidx.compose.material3.Text(
+            text = value.name,
+            style = MaterialTheme.typography.titleMedium,
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/laxotters/clipy/core/designsystem/component/BottomSheet.kt
+++ b/core/designsystem/src/main/java/com/laxotters/clipy/core/designsystem/component/BottomSheet.kt
@@ -42,6 +42,12 @@ import com.laxotters.clipy.core.designsystem.theme.ClipyTheme
 import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineScope
 
+/**
+ * [value]를 기준으로 BottomSheet 위치와 content를 표시합니다.
+ *
+ * 사용자가 drag를 끝내면 다음 상태를 [onValueChange]로 전달합니다.
+ * 호출자는 전달받은 값을 다시 [value]에 반영해 상태를 확정합니다.
+ */
 @Composable
 fun ClipyBottomSheetLayout(
     value: ClipyBottomSheetValue,
@@ -51,6 +57,7 @@ fun ClipyBottomSheetLayout(
     sheetContent: @Composable ColumnScope.(ClipyBottomSheetValue) -> Unit,
 ) {
     val dragController = remember { ClipyBottomSheetDragController() }
+    // BottomSheet가 움직일 수 있는 부모 영역의 실제 px 높이입니다.
     var layoutHeightPx by remember { mutableFloatStateOf(0f) }
     val policy = rememberClipyBottomSheetPolicy(layoutHeightPx)
     val targetOffset = policy.offsetFor(value)
@@ -102,6 +109,11 @@ fun ClipyBottomSheetLayout(
     }
 }
 
+/**
+ * dp로 정의된 visible height를 px offset anchor로 변환합니다.
+ *
+ * 상태별 anchor offsetY는 availableHeight - visibleHeight입니다.
+ */
 @Composable
 private fun rememberClipyBottomSheetPolicy(
     availableHeight: Float,
@@ -222,6 +234,7 @@ private fun ClipyBottomSheetAnimatedContent(
     }
 }
 
+/** sheet가 아래로 내려간 만큼 부족해지는 Column 하단 높이를 채웁니다. */
 @Composable
 private fun ClipyBottomSheetBottomSpacer(
     hiddenOffset: Float,
@@ -239,6 +252,9 @@ private fun ClipyBottomSheetBottomSpacer(
     )
 }
 
+/**
+ * BottomSheet의 현재 offsetY와 target anchor 이동을 관리합니다.
+ */
 private class ClipyBottomSheetDragController {
     private var currentOffsetY by mutableFloatStateOf(0f)
     private val offsetYAnimatable = Animatable(0f)
@@ -247,15 +263,19 @@ private class ClipyBottomSheetDragController {
     var isDragging by mutableStateOf(false)
         private set
 
+    // drag 시작점부터 현재 지점까지 누적된 y축 이동량입니다.
+    // 음수는 위로 끄는 방향이고, 양수는 아래로 끄는 방향입니다.
     var dragTranslationY by mutableFloatStateOf(0f)
         private set
 
     var isSettling by mutableStateOf(false)
         private set
 
+    // settle 중에는 drag 종료 시점의 target content를 유지합니다.
     var settlingTargetValue by mutableStateOf<ClipyBottomSheetValue?>(null)
         private set
 
+    /** 현재 프레임에서 화면에 적용할 offsetY를 반환합니다. */
     fun displayedOffset(targetOffset: Float): Float = when {
         !isPositionInitialized -> targetOffset
         isSettling -> offsetYAnimatable.value
@@ -276,6 +296,7 @@ private class ClipyBottomSheetDragController {
         currentOffsetY = policy.clampOffsetY(currentOffsetY + delta)
     }
 
+    /** 외부에서 전달된 [targetOffset]으로 sheet 위치를 동기화합니다. */
     suspend fun syncTo(targetOffset: Float) {
         if (!isPositionInitialized) {
             offsetYAnimatable.snapTo(targetOffset)
@@ -295,6 +316,7 @@ private class ClipyBottomSheetDragController {
         }
     }
 
+    /** drag 종료 결과를 target state로 변환하고 target anchor까지 이동합니다. */
     suspend fun settle(
         currentValue: ClipyBottomSheetValue,
         velocity: Float,

--- a/core/designsystem/src/main/java/com/laxotters/clipy/core/designsystem/component/BottomSheet.kt
+++ b/core/designsystem/src/main/java/com/laxotters/clipy/core/designsystem/component/BottomSheet.kt
@@ -1,11 +1,16 @@
 package com.laxotters.clipy.core.designsystem.component
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -19,8 +24,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -33,17 +40,26 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.laxotters.clipy.core.designsystem.theme.ClipyTheme
 import kotlin.math.roundToInt
+import kotlinx.coroutines.CoroutineScope
 
 @Composable
 fun ClipyBottomSheetLayout(
     value: ClipyBottomSheetValue,
+    onValueChange: (ClipyBottomSheetValue) -> Unit,
     modifier: Modifier = Modifier,
     headerContent: @Composable ColumnScope.(ClipyBottomSheetValue) -> Unit = {},
     sheetContent: @Composable ColumnScope.(ClipyBottomSheetValue) -> Unit,
 ) {
+    val dragController = remember { ClipyBottomSheetDragController() }
     var layoutHeightPx by remember { mutableFloatStateOf(0f) }
     val policy = rememberClipyBottomSheetPolicy(layoutHeightPx)
-    val offsetY = policy.offsetFor(value)
+    val targetOffset = policy.offsetFor(value)
+
+    LaunchedEffect(layoutHeightPx, policy, value) {
+        if (layoutHeightPx > 0f) {
+            dragController.syncTo(targetOffset)
+        }
+    }
 
     Box(
         modifier = modifier
@@ -54,9 +70,31 @@ fun ClipyBottomSheetLayout(
     ) {
         if (layoutHeightPx > 0f) {
             ClipyBottomSheetSurface(
-                value = value,
-                offsetY = offsetY,
-                hiddenOffset = policy.offsetFor(ClipyBottomSheetValue.HIDDEN),
+                presentation = ClipyBottomSheetPresentation(
+                    value = value,
+                    offsetY = dragController.displayedOffset(targetOffset),
+                    isDragging = dragController.isDragging,
+                    dragTranslationY = dragController.dragTranslationY,
+                    settlingTargetValue = dragController.settlingTargetValue,
+                ),
+                policy = policy,
+                dragCallbacks = ClipyBottomSheetDragCallbacks(
+                    onDragStarted = { dragController.startDrag() },
+                    onDrag = { delta ->
+                        dragController.dragBy(
+                            delta = delta,
+                            policy = policy,
+                        )
+                    },
+                    onDragStopped = { velocity ->
+                        dragController.settle(
+                            currentValue = value,
+                            velocity = velocity,
+                            policy = policy,
+                            onValueChange = onValueChange,
+                        )
+                    },
+                ),
                 headerContent = headerContent,
                 sheetContent = sheetContent,
             )
@@ -92,17 +130,27 @@ private fun rememberClipyBottomSheetPolicy(
 
 @Composable
 private fun ClipyBottomSheetSurface(
-    value: ClipyBottomSheetValue,
-    offsetY: Float,
-    hiddenOffset: Float,
+    presentation: ClipyBottomSheetPresentation,
+    policy: ClipyBottomSheetPolicy,
+    dragCallbacks: ClipyBottomSheetDragCallbacks,
     modifier: Modifier = Modifier,
     headerContent: @Composable ColumnScope.(ClipyBottomSheetValue) -> Unit,
     sheetContent: @Composable ColumnScope.(ClipyBottomSheetValue) -> Unit,
 ) {
+    val valueForContent = policy.valueForContent(
+        ClipyBottomSheetContentContext(
+            currentValue = presentation.value,
+            offsetY = presentation.offsetY,
+            translationY = presentation.dragTranslationY,
+            isDragging = presentation.isDragging,
+            settlingTargetValue = presentation.settlingTargetValue,
+        ),
+    )
+
     Column(
         modifier = modifier
             .fillMaxSize()
-            .offsetY(offsetY)
+            .offsetY(presentation.offsetY)
             .shadow(
                 elevation = ClipyBottomSheetDefaults.SheetElevation,
                 shape = ClipyBottomSheetDefaults.SheetShape,
@@ -111,22 +159,43 @@ private fun ClipyBottomSheetSurface(
             .background(
                 color = MaterialTheme.colorScheme.surface,
                 shape = ClipyBottomSheetDefaults.SheetShape,
+            )
+            .draggable(
+                orientation = Orientation.Vertical,
+                state = rememberDraggableState(onDelta = dragCallbacks.onDrag),
+                enabled = presentation.value != ClipyBottomSheetValue.HIDDEN,
+                onDragStarted = { dragCallbacks.onDragStarted() },
+                onDragStopped = dragCallbacks.onDragStopped,
             ),
     ) {
-        if (value != ClipyBottomSheetValue.HIDDEN) {
+        if (presentation.value != ClipyBottomSheetValue.HIDDEN) {
             ClipyBottomSheetHandle()
         }
-        headerContent(value)
+        headerContent(valueForContent)
         ClipyBottomSheetAnimatedContent(
-            valueForContent = value,
+            valueForContent = valueForContent,
             sheetContent = sheetContent,
         )
         ClipyBottomSheetBottomSpacer(
-            hiddenOffset = hiddenOffset,
-            offsetY = offsetY,
+            hiddenOffset = policy.offsetFor(ClipyBottomSheetValue.HIDDEN),
+            offsetY = presentation.offsetY,
         )
     }
 }
+
+private data class ClipyBottomSheetPresentation(
+    val value: ClipyBottomSheetValue,
+    val offsetY: Float,
+    val isDragging: Boolean,
+    val dragTranslationY: Float,
+    val settlingTargetValue: ClipyBottomSheetValue?,
+)
+
+private data class ClipyBottomSheetDragCallbacks(
+    val onDragStarted: () -> Unit,
+    val onDrag: (Float) -> Unit,
+    val onDragStopped: suspend CoroutineScope.(Float) -> Unit,
+)
 
 @Composable
 private fun ClipyBottomSheetAnimatedContent(
@@ -168,6 +237,95 @@ private fun ClipyBottomSheetBottomSpacer(
             },
         ),
     )
+}
+
+private class ClipyBottomSheetDragController {
+    private var currentOffsetY by mutableFloatStateOf(0f)
+    private val offsetYAnimatable = Animatable(0f)
+    private var isPositionInitialized by mutableStateOf(false)
+
+    var isDragging by mutableStateOf(false)
+        private set
+
+    var dragTranslationY by mutableFloatStateOf(0f)
+        private set
+
+    var isSettling by mutableStateOf(false)
+        private set
+
+    var settlingTargetValue by mutableStateOf<ClipyBottomSheetValue?>(null)
+        private set
+
+    fun displayedOffset(targetOffset: Float): Float = when {
+        !isPositionInitialized -> targetOffset
+        isSettling -> offsetYAnimatable.value
+        else -> currentOffsetY
+    }
+
+    fun startDrag() {
+        settlingTargetValue = null
+        dragTranslationY = 0f
+        isDragging = true
+    }
+
+    fun dragBy(
+        delta: Float,
+        policy: ClipyBottomSheetPolicy,
+    ) {
+        dragTranslationY += delta
+        currentOffsetY = policy.clampOffsetY(currentOffsetY + delta)
+    }
+
+    suspend fun syncTo(targetOffset: Float) {
+        if (!isPositionInitialized) {
+            offsetYAnimatable.snapTo(targetOffset)
+            currentOffsetY = targetOffset
+            isPositionInitialized = true
+        } else if (currentOffsetY != targetOffset) {
+            settlingTargetValue = null
+            isSettling = true
+            offsetYAnimatable.stop()
+            offsetYAnimatable.snapTo(currentOffsetY)
+            offsetYAnimatable.animateTo(
+                targetValue = targetOffset,
+                animationSpec = spring(),
+            )
+            currentOffsetY = offsetYAnimatable.value
+            isSettling = false
+        }
+    }
+
+    suspend fun settle(
+        currentValue: ClipyBottomSheetValue,
+        velocity: Float,
+        policy: ClipyBottomSheetPolicy,
+        onValueChange: (ClipyBottomSheetValue) -> Unit,
+    ) {
+        val targetValue = policy.targetValue(
+            from = currentValue,
+            dragEnd = ClipyBottomSheetDragEnd(
+                translationY = dragTranslationY,
+                velocityY = velocity,
+                endOffsetY = currentOffsetY,
+            ),
+        )
+
+        settlingTargetValue = targetValue
+        isDragging = false
+        dragTranslationY = 0f
+        if (targetValue != currentValue) {
+            onValueChange(targetValue)
+        }
+        isSettling = true
+        offsetYAnimatable.snapTo(currentOffsetY)
+        offsetYAnimatable.animateTo(
+            targetValue = policy.offsetFor(targetValue),
+            animationSpec = spring(),
+        )
+        currentOffsetY = offsetYAnimatable.value
+        isSettling = false
+        settlingTargetValue = null
+    }
 }
 
 @Composable
@@ -237,6 +395,7 @@ private fun ClipyBottomSheetPreviewContent(value: ClipyBottomSheetValue) {
         ) {
             ClipyBottomSheetLayout(
                 value = value,
+                onValueChange = {},
                 sheetContent = { targetValue ->
                     ClipyBottomSheetPreviewSheetContent(value = targetValue)
                 },

--- a/core/designsystem/src/main/java/com/laxotters/clipy/core/designsystem/component/ClipyBottomSheetDefaults.kt
+++ b/core/designsystem/src/main/java/com/laxotters/clipy/core/designsystem/component/ClipyBottomSheetDefaults.kt
@@ -1,0 +1,25 @@
+package com.laxotters.clipy.core.designsystem.component
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+object ClipyBottomSheetDefaults {
+    val HiddenHeight: Dp = 0.dp
+    val MinimizedHeight: Dp = 120.dp
+    val PeekHeight: Dp = 286.dp
+    val RetentionBand: Dp = 20.dp
+    val VelocityThreshold: Dp = 1_400.dp
+    val HandleHeight: Dp = 32.dp
+    val HandleWidth: Dp = 42.dp
+    val HandleIndicatorHeight: Dp = 4.dp
+    val SheetShape = RoundedCornerShape(
+        topStart = 28.dp,
+        topEnd = 28.dp,
+    )
+    val SheetElevation: Dp = 16.dp
+    val HandleColor = Color(0xFFE4E4E7)
+    const val CONTENT_FADE_IN_MILLIS = 500
+    const val CONTENT_FADE_OUT_MILLIS = 500
+}

--- a/core/designsystem/src/main/java/com/laxotters/clipy/core/designsystem/component/ClipyBottomSheetPolicy.kt
+++ b/core/designsystem/src/main/java/com/laxotters/clipy/core/designsystem/component/ClipyBottomSheetPolicy.kt
@@ -1,0 +1,240 @@
+package com.laxotters.clipy.core.designsystem.component
+
+import kotlin.math.abs
+
+internal data class ClipyBottomSheetAnchors(
+    val expanded: Float,
+    val peek: Float,
+    val minimized: Float,
+    val hidden: Float,
+) {
+    fun offsetFor(value: ClipyBottomSheetValue): Float =
+        when (value) {
+            ClipyBottomSheetValue.HIDDEN -> hidden
+            ClipyBottomSheetValue.MINIMIZED -> minimized
+            ClipyBottomSheetValue.PEEK -> peek
+            ClipyBottomSheetValue.EXPANDED -> expanded
+        }
+}
+
+internal data class ClipyBottomSheetDragEnd(
+    val translationY: Float,
+    val velocityY: Float,
+    val endOffsetY: Float,
+)
+
+internal data class ClipyBottomSheetContentContext(
+    val currentValue: ClipyBottomSheetValue,
+    val offsetY: Float,
+    val translationY: Float,
+    val isDragging: Boolean,
+    val settlingTargetValue: ClipyBottomSheetValue?,
+)
+
+internal data class ClipyBottomSheetPolicy(
+    val anchors: ClipyBottomSheetAnchors,
+    val velocityThreshold: Float,
+    val retentionBand: Float,
+) {
+    fun offsetFor(value: ClipyBottomSheetValue): Float =
+        anchors.offsetFor(value)
+
+    fun clampOffsetY(offsetY: Float): Float =
+        offsetY.coerceIn(
+            minimumValue = anchors.expanded,
+            maximumValue = anchors.hidden,
+        )
+
+    fun targetValue(
+        from: ClipyBottomSheetValue,
+        dragEnd: ClipyBottomSheetDragEnd,
+    ): ClipyBottomSheetValue {
+        if (from == ClipyBottomSheetValue.HIDDEN) {
+            return ClipyBottomSheetValue.HIDDEN
+        }
+
+        val fastDirection = fastDragDirection(dragEnd.velocityY)
+        if (fastDirection != null) {
+            return fastTargetValue(
+                from = from,
+                direction = fastDirection,
+            )
+        }
+
+        return slowTargetValue(
+            from = from,
+            translationY = dragEnd.translationY,
+            endOffsetY = dragEnd.endOffsetY,
+        )
+    }
+
+    fun valueForContent(context: ClipyBottomSheetContentContext): ClipyBottomSheetValue =
+        when {
+            context.isDragging -> slowTargetValue(
+                from = context.currentValue,
+                translationY = context.translationY,
+                endOffsetY = context.offsetY,
+            )
+            context.settlingTargetValue != null -> context.settlingTargetValue
+            else -> context.currentValue
+        }
+
+    private fun slowTargetValue(
+        from: ClipyBottomSheetValue,
+        translationY: Float,
+        endOffsetY: Float,
+    ): ClipyBottomSheetValue {
+        if (from == ClipyBottomSheetValue.HIDDEN) {
+            return ClipyBottomSheetValue.HIDDEN
+        }
+
+        val endOffset = clampOffsetY(endOffsetY)
+        val currentOffset = anchors.offsetFor(from)
+        val direction = dragDirection(
+            translationY = translationY,
+            currentOffset = currentOffset,
+            endOffset = endOffset,
+        ) ?: return from
+
+        return slowTargetValue(
+            from = from,
+            direction = direction,
+            endOffset = endOffset,
+        )
+    }
+
+    private fun fastDragDirection(velocityY: Float): DragDirection? {
+        if (abs(velocityY) < velocityThreshold) {
+            return null
+        }
+
+        return if (velocityY < 0f) {
+            DragDirection.UPWARD
+        } else {
+            DragDirection.DOWNWARD
+        }
+    }
+
+    private fun fastTargetValue(
+        from: ClipyBottomSheetValue,
+        direction: DragDirection,
+    ): ClipyBottomSheetValue =
+        when (from) {
+            ClipyBottomSheetValue.HIDDEN -> ClipyBottomSheetValue.HIDDEN
+            ClipyBottomSheetValue.MINIMIZED -> when (direction) {
+                DragDirection.UPWARD -> ClipyBottomSheetValue.EXPANDED
+                DragDirection.DOWNWARD -> ClipyBottomSheetValue.HIDDEN
+            }
+            ClipyBottomSheetValue.PEEK -> when (direction) {
+                DragDirection.UPWARD -> ClipyBottomSheetValue.EXPANDED
+                DragDirection.DOWNWARD -> ClipyBottomSheetValue.MINIMIZED
+            }
+            ClipyBottomSheetValue.EXPANDED -> when (direction) {
+                DragDirection.UPWARD -> ClipyBottomSheetValue.EXPANDED
+                DragDirection.DOWNWARD -> ClipyBottomSheetValue.MINIMIZED
+            }
+        }
+
+    private fun slowTargetValue(
+        from: ClipyBottomSheetValue,
+        direction: DragDirection,
+        endOffset: Float,
+    ): ClipyBottomSheetValue {
+        val metrics = SlowDragMetrics(
+            currentOffset = anchors.offsetFor(from),
+            endOffset = endOffset,
+            expandedOffset = anchors.expanded,
+            minimizedOffset = anchors.minimized,
+            retentionBand = retentionBand.coerceAtLeast(0f),
+        )
+
+        return when (from) {
+            ClipyBottomSheetValue.HIDDEN -> ClipyBottomSheetValue.HIDDEN
+            ClipyBottomSheetValue.EXPANDED -> slowExpandedTarget(direction, metrics)
+            ClipyBottomSheetValue.PEEK -> slowPeekTarget(direction, metrics)
+            ClipyBottomSheetValue.MINIMIZED -> slowMinimizedTarget(direction, metrics)
+        }
+    }
+
+    private fun slowExpandedTarget(
+        direction: DragDirection,
+        metrics: SlowDragMetrics,
+    ): ClipyBottomSheetValue =
+        when (direction) {
+            DragDirection.UPWARD -> ClipyBottomSheetValue.EXPANDED
+            DragDirection.DOWNWARD -> when {
+                metrics.isNearCurrentWhenDraggingDown() -> ClipyBottomSheetValue.EXPANDED
+                metrics.isNearMinimized() -> ClipyBottomSheetValue.MINIMIZED
+                else -> ClipyBottomSheetValue.PEEK
+            }
+        }
+
+    private fun slowPeekTarget(
+        direction: DragDirection,
+        metrics: SlowDragMetrics,
+    ): ClipyBottomSheetValue =
+        when (direction) {
+            DragDirection.UPWARD -> when {
+                metrics.isNearCurrentWhenDraggingUp() -> ClipyBottomSheetValue.PEEK
+                else -> ClipyBottomSheetValue.EXPANDED
+            }
+            DragDirection.DOWNWARD -> when {
+                metrics.isNearCurrentWhenDraggingDown() -> ClipyBottomSheetValue.PEEK
+                else -> ClipyBottomSheetValue.MINIMIZED
+            }
+        }
+
+    private fun slowMinimizedTarget(
+        direction: DragDirection,
+        metrics: SlowDragMetrics,
+    ): ClipyBottomSheetValue =
+        when (direction) {
+            DragDirection.UPWARD -> when {
+                metrics.isNearCurrentWhenDraggingUp() -> ClipyBottomSheetValue.MINIMIZED
+                metrics.isNearExpanded() -> ClipyBottomSheetValue.EXPANDED
+                else -> ClipyBottomSheetValue.PEEK
+            }
+            DragDirection.DOWNWARD -> when {
+                metrics.isNearCurrentWhenDraggingDown() -> ClipyBottomSheetValue.MINIMIZED
+                else -> ClipyBottomSheetValue.HIDDEN
+            }
+        }
+
+    private fun dragDirection(
+        translationY: Float,
+        currentOffset: Float,
+        endOffset: Float,
+    ): DragDirection? =
+        when {
+            translationY < 0f -> DragDirection.UPWARD
+            translationY > 0f -> DragDirection.DOWNWARD
+            endOffset < currentOffset -> DragDirection.UPWARD
+            endOffset > currentOffset -> DragDirection.DOWNWARD
+            else -> null
+        }
+
+    private enum class DragDirection {
+        UPWARD,
+        DOWNWARD,
+    }
+
+    private data class SlowDragMetrics(
+        val currentOffset: Float,
+        val endOffset: Float,
+        val expandedOffset: Float,
+        val minimizedOffset: Float,
+        val retentionBand: Float,
+    ) {
+        fun isNearCurrentWhenDraggingUp(): Boolean =
+            endOffset >= currentOffset - retentionBand
+
+        fun isNearCurrentWhenDraggingDown(): Boolean =
+            endOffset <= currentOffset + retentionBand
+
+        fun isNearExpanded(): Boolean =
+            endOffset <= expandedOffset + retentionBand
+
+        fun isNearMinimized(): Boolean =
+            endOffset >= minimizedOffset - retentionBand
+    }
+}

--- a/core/designsystem/src/main/java/com/laxotters/clipy/core/designsystem/component/ClipyBottomSheetPolicy.kt
+++ b/core/designsystem/src/main/java/com/laxotters/clipy/core/designsystem/component/ClipyBottomSheetPolicy.kt
@@ -2,6 +2,7 @@ package com.laxotters.clipy.core.designsystem.component
 
 import kotlin.math.abs
 
+/** 상태별 sheet top anchor(offsetY)입니다. */
 internal data class ClipyBottomSheetAnchors(
     val expanded: Float,
     val peek: Float,
@@ -17,12 +18,14 @@ internal data class ClipyBottomSheetAnchors(
         }
 }
 
+/** drag 종료 후 target state를 판단할 때 사용하는 drag 결과입니다. */
 internal data class ClipyBottomSheetDragEnd(
     val translationY: Float,
     val velocityY: Float,
     val endOffsetY: Float,
 )
 
+/** headerContent와 sheetContent에 전달할 value 판단에 필요한 현재 sheet 정보입니다. */
 internal data class ClipyBottomSheetContentContext(
     val currentValue: ClipyBottomSheetValue,
     val offsetY: Float,
@@ -31,6 +34,13 @@ internal data class ClipyBottomSheetContentContext(
     val settlingTargetValue: ClipyBottomSheetValue?,
 )
 
+/**
+ * anchor와 drag 결과를 기준으로 target state를 결정합니다.
+ * 또한 headerContent와 sheetContent에 전달할 value를 결정합니다.
+ *
+ * anchor는 BottomSheet top의 offsetY입니다.
+ * offsetY가 작을수록 sheet는 위에 있고, 커질수록 아래로 내려갑니다.
+ */
 internal data class ClipyBottomSheetPolicy(
     val anchors: ClipyBottomSheetAnchors,
     val velocityThreshold: Float,

--- a/core/designsystem/src/main/java/com/laxotters/clipy/core/designsystem/component/ClipyBottomSheetValue.kt
+++ b/core/designsystem/src/main/java/com/laxotters/clipy/core/designsystem/component/ClipyBottomSheetValue.kt
@@ -1,0 +1,8 @@
+package com.laxotters.clipy.core.designsystem.component
+
+enum class ClipyBottomSheetValue {
+    HIDDEN,
+    MINIMIZED,
+    PEEK,
+    EXPANDED,
+}

--- a/core/designsystem/src/test/java/com/laxotters/clipy/core/designsystem/component/ClipyBottomSheetPolicyTest.kt
+++ b/core/designsystem/src/test/java/com/laxotters/clipy/core/designsystem/component/ClipyBottomSheetPolicyTest.kt
@@ -1,0 +1,207 @@
+package com.laxotters.clipy.core.designsystem.component
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ClipyBottomSheetPolicyTest {
+    private val policy = ClipyBottomSheetPolicy(
+        anchors = ClipyBottomSheetAnchors(
+            expanded = 0f,
+            peek = 400f,
+            minimized = 700f,
+            hidden = 1_000f,
+        ),
+        velocityThreshold = VELOCITY_THRESHOLD,
+        retentionBand = RETENTION_BAND,
+    )
+
+    @Test
+    fun offsetFor_returnsAnchorForState() {
+        assertEquals(400f, policy.offsetFor(ClipyBottomSheetValue.PEEK), 0f)
+    }
+
+    @Test
+    fun offsetY_clampOffsetY_clampsToAnchorRange() {
+        assertEquals(0f, policy.clampOffsetY(-100f), 0f)
+        assertEquals(1_000f, policy.clampOffsetY(1_200f), 0f)
+    }
+
+    @Test
+    fun offsetInsideRetentionBand_slowDragRelease_keepsCurrentValue() {
+        val targetValue = targetValue(
+            currentValue = ClipyBottomSheetValue.PEEK,
+            endOffsetY = 410f,
+            translationY = 10f,
+        )
+
+        assertEquals(ClipyBottomSheetValue.PEEK, targetValue)
+    }
+
+    @Test
+    fun minimizedDragUp_insideExpandedAnchorBand_targetsExpanded() {
+        val targetValue = targetValue(
+            currentValue = ClipyBottomSheetValue.MINIMIZED,
+            endOffsetY = 20f,
+            translationY = -680f,
+        )
+
+        assertEquals(ClipyBottomSheetValue.EXPANDED, targetValue)
+    }
+
+    @Test
+    fun minimizedDragUp_beforeExpandedAnchorBand_targetsPeek() {
+        val targetValue = targetValue(
+            currentValue = ClipyBottomSheetValue.MINIMIZED,
+            endOffsetY = 380f,
+            translationY = -320f,
+        )
+
+        assertEquals(ClipyBottomSheetValue.PEEK, targetValue)
+    }
+
+    @Test
+    fun slowDragRelease_targetValue_resolvesByAnchorAndDirection() {
+        val cases = listOf(
+            DragCase(
+                currentValue = ClipyBottomSheetValue.EXPANDED,
+                endOffsetY = 390f,
+                translationY = 390f,
+                expectedValue = ClipyBottomSheetValue.PEEK,
+            ),
+            DragCase(
+                currentValue = ClipyBottomSheetValue.EXPANDED,
+                endOffsetY = 690f,
+                translationY = 690f,
+                expectedValue = ClipyBottomSheetValue.MINIMIZED,
+            ),
+            DragCase(
+                currentValue = ClipyBottomSheetValue.MINIMIZED,
+                endOffsetY = 730f,
+                translationY = 30f,
+                expectedValue = ClipyBottomSheetValue.HIDDEN,
+            ),
+            DragCase(
+                currentValue = ClipyBottomSheetValue.PEEK,
+                endOffsetY = 370f,
+                translationY = -30f,
+                expectedValue = ClipyBottomSheetValue.EXPANDED,
+            ),
+            DragCase(
+                currentValue = ClipyBottomSheetValue.PEEK,
+                endOffsetY = 970f,
+                translationY = 570f,
+                expectedValue = ClipyBottomSheetValue.MINIMIZED,
+            ),
+        )
+
+        cases.forEach { case ->
+            assertEquals(
+                case.expectedValue,
+                targetValue(
+                    currentValue = case.currentValue,
+                    endOffsetY = case.endOffsetY,
+                    translationY = case.translationY,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun fastUpwardVelocity_targetValue_resolvesByDirectionPolicy() {
+        val cases = listOf(
+            ClipyBottomSheetValue.HIDDEN to ClipyBottomSheetValue.HIDDEN,
+            ClipyBottomSheetValue.MINIMIZED to ClipyBottomSheetValue.EXPANDED,
+            ClipyBottomSheetValue.PEEK to ClipyBottomSheetValue.EXPANDED,
+            ClipyBottomSheetValue.EXPANDED to ClipyBottomSheetValue.EXPANDED,
+        )
+
+        cases.forEach { (currentValue, expectedValue) ->
+            assertEquals(
+                expectedValue,
+                targetValue(
+                    currentValue = currentValue,
+                    endOffsetY = policy.offsetFor(currentValue),
+                    velocityY = -1_500f,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun fastDownwardVelocity_targetValue_resolvesByDirectionPolicy() {
+        val cases = listOf(
+            ClipyBottomSheetValue.HIDDEN to ClipyBottomSheetValue.HIDDEN,
+            ClipyBottomSheetValue.EXPANDED to ClipyBottomSheetValue.MINIMIZED,
+            ClipyBottomSheetValue.PEEK to ClipyBottomSheetValue.MINIMIZED,
+            ClipyBottomSheetValue.MINIMIZED to ClipyBottomSheetValue.HIDDEN,
+        )
+
+        cases.forEach { (currentValue, expectedValue) ->
+            assertEquals(
+                expectedValue,
+                targetValue(
+                    currentValue = currentValue,
+                    endOffsetY = policy.offsetFor(currentValue),
+                    velocityY = 1_500f,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun dragging_valueForContent_resolvesBySlowDragPolicy() {
+        val valueForContent = policy.valueForContent(
+            ClipyBottomSheetContentContext(
+                currentValue = ClipyBottomSheetValue.MINIMIZED,
+                offsetY = 380f,
+                translationY = -320f,
+                isDragging = true,
+                settlingTargetValue = null,
+            ),
+        )
+
+        assertEquals(ClipyBottomSheetValue.PEEK, valueForContent)
+    }
+
+    @Test
+    fun settlingTargetValue_valueForContent_keepsSettlingTargetValue() {
+        val valueForContent = policy.valueForContent(
+            ClipyBottomSheetContentContext(
+                currentValue = ClipyBottomSheetValue.MINIMIZED,
+                offsetY = 710f,
+                translationY = 0f,
+                isDragging = false,
+                settlingTargetValue = ClipyBottomSheetValue.PEEK,
+            ),
+        )
+
+        assertEquals(ClipyBottomSheetValue.PEEK, valueForContent)
+    }
+
+    private fun targetValue(
+        currentValue: ClipyBottomSheetValue,
+        endOffsetY: Float,
+        translationY: Float = 0f,
+        velocityY: Float = 0f,
+    ): ClipyBottomSheetValue =
+        policy.targetValue(
+            from = currentValue,
+            dragEnd = ClipyBottomSheetDragEnd(
+                translationY = translationY,
+                velocityY = velocityY,
+                endOffsetY = endOffsetY,
+            ),
+        )
+
+    private data class DragCase(
+        val currentValue: ClipyBottomSheetValue,
+        val endOffsetY: Float,
+        val translationY: Float,
+        val expectedValue: ClipyBottomSheetValue,
+    )
+
+    private companion object {
+        const val RETENTION_BAND = 20f
+        const val VELOCITY_THRESHOLD = 1_400f
+    }
+}

--- a/domain/src/main/java/com/laxotters/clipy/domain/model/SessionViewState.kt
+++ b/domain/src/main/java/com/laxotters/clipy/domain/model/SessionViewState.kt
@@ -12,6 +12,7 @@ data class SessionViewState(
 
 enum class BottomSheetState {
     HIDDEN,
+    MINIMIZED,
     PEEK,
     EXPANDED,
 }

--- a/feature/session/build.gradle.kts
+++ b/feature/session/build.gradle.kts
@@ -9,4 +9,6 @@ setNamespace("feature.session")
 dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation3.runtime)
+
+    testImplementation(libs.junit)
 }

--- a/feature/session/build.gradle.kts
+++ b/feature/session/build.gradle.kts
@@ -7,5 +7,6 @@ plugins {
 setNamespace("feature.session")
 
 dependencies {
+    implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation3.runtime)
 }

--- a/feature/session/src/main/java/com/laxotters/clipy/feature/session/SessionContract.kt
+++ b/feature/session/src/main/java/com/laxotters/clipy/feature/session/SessionContract.kt
@@ -12,12 +12,12 @@ data class SessionUiState(
 ) : UiState
 
 sealed interface SessionUiEvent : UiEvent {
-    data class Entered(
+    data class ScreenEntered(
         val sessionId: String,
         val initialUrl: String,
     ) : SessionUiEvent
 
-    data class WebPageStateChanged(
+    data class PageLoaded(
         val url: String,
         val canGoBack: Boolean,
         val canGoForward: Boolean,

--- a/feature/session/src/main/java/com/laxotters/clipy/feature/session/SessionContract.kt
+++ b/feature/session/src/main/java/com/laxotters/clipy/feature/session/SessionContract.kt
@@ -1,14 +1,17 @@
 package com.laxotters.clipy.feature.session
 
+import com.laxotters.clipy.core.designsystem.component.ClipyBottomSheetValue
 import com.laxotters.clipy.core.ui.base.UiEvent
 import com.laxotters.clipy.core.ui.base.UiSideEffect
 import com.laxotters.clipy.core.ui.base.UiState
+import com.laxotters.clipy.domain.model.BottomSheetState
 
 data class SessionUiState(
     val sessionId: String = "",
     val currentUrl: String = "",
     val canGoBack: Boolean = false,
     val canGoForward: Boolean = false,
+    val bottomSheetState: BottomSheetState = BottomSheetState.PEEK,
 ) : UiState
 
 sealed interface SessionUiEvent : UiEvent {
@@ -21,6 +24,10 @@ sealed interface SessionUiEvent : UiEvent {
         val url: String,
         val canGoBack: Boolean,
         val canGoForward: Boolean,
+    ) : SessionUiEvent
+
+    data class BottomSheetValueChanged(
+        val value: ClipyBottomSheetValue,
     ) : SessionUiEvent
 }
 

--- a/feature/session/src/main/java/com/laxotters/clipy/feature/session/SessionScreen.kt
+++ b/feature/session/src/main/java/com/laxotters/clipy/feature/session/SessionScreen.kt
@@ -52,7 +52,7 @@ fun SessionRoute(
 
     LaunchedEffect(sessionId, initialUrl) {
         viewModel.dispatch(
-            SessionUiEvent.Entered(
+            SessionUiEvent.ScreenEntered(
                 sessionId = sessionId,
                 initialUrl = initialUrl,
             ),
@@ -73,7 +73,7 @@ fun SessionRoute(
                 controller = webViewController,
                 onPageStateChanged = { url, canGoBack, canGoForward ->
                     viewModel.dispatch(
-                        SessionUiEvent.WebPageStateChanged(
+                        SessionUiEvent.PageLoaded(
                             url = url,
                             canGoBack = canGoBack,
                             canGoForward = canGoForward,

--- a/feature/session/src/main/java/com/laxotters/clipy/feature/session/SessionScreen.kt
+++ b/feature/session/src/main/java/com/laxotters/clipy/feature/session/SessionScreen.kt
@@ -7,14 +7,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -32,7 +30,10 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.laxotters.clipy.core.designsystem.component.ClipyBottomSheetLayout
+import com.laxotters.clipy.core.designsystem.component.ClipyBottomSheetValue
 import com.laxotters.clipy.core.designsystem.theme.ClipyTheme
+import com.laxotters.clipy.domain.model.BottomSheetState
 import com.laxotters.clipy.feature.session.webview.SessionWebView
 import com.laxotters.clipy.feature.session.webview.rememberSessionWebViewController
 
@@ -40,12 +41,13 @@ import com.laxotters.clipy.feature.session.webview.rememberSessionWebViewControl
 fun SessionRoute(
     sessionId: String,
     initialUrl: String,
-    modifier: Modifier = Modifier,
     onHomeClick: () -> Unit = {},
+    modifier: Modifier = Modifier,
     viewModel: SessionViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val webViewController = rememberSessionWebViewController()
+
     val screenState = state.copy(
         sessionId = state.sessionId.ifBlank { sessionId },
         currentUrl = state.currentUrl.ifBlank { initialUrl.ifBlank { DEFAULT_HOME_URL } },
@@ -68,30 +70,29 @@ fun SessionRoute(
 
     SessionScreen(
         state = screenState,
-        actions = SessionScreenActions(
-            onHomeClick = onHomeClick,
-            onBackClick = webViewController::goBack,
-            onForwardClick = webViewController::goForward,
-            onRefreshClick = webViewController::reload,
-        ),
-        webContent = {
-            SessionWebView(
-                initialUrl = state.currentUrl,
-                controller = webViewController,
-                onPageStateChanged = { url, canGoBack, canGoForward ->
-                    viewModel.dispatch(
-                        SessionUiEvent.PageLoaded(
-                            url = url,
-                            canGoBack = canGoBack,
-                            canGoForward = canGoForward,
-                        ),
-                    )
-                },
-                modifier = Modifier.fillMaxSize(),
+        onHomeClick = onHomeClick,
+        onBottomSheetValueChange = { bottomSheetValue ->
+            viewModel.dispatch(
+                SessionUiEvent.BottomSheetValueChanged(bottomSheetValue),
             )
         },
         modifier = modifier,
-    )
+    ) {
+        SessionWebView(
+            initialUrl = screenState.currentUrl,
+            controller = webViewController,
+            onPageStateChanged = { url, canGoBack, canGoForward ->
+                viewModel.dispatch(
+                    SessionUiEvent.PageLoaded(
+                        url = url,
+                        canGoBack = canGoBack,
+                        canGoForward = canGoForward,
+                    ),
+                )
+            },
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
 }
 
 @Composable
@@ -109,30 +110,20 @@ private fun SessionBackHandler(
     }
 }
 
-private data class SessionScreenActions(
-    val onHomeClick: () -> Unit,
-    val onBackClick: () -> Unit,
-    val onForwardClick: () -> Unit,
-    val onRefreshClick: () -> Unit,
-)
-
 @Composable
 private fun SessionScreen(
     state: SessionUiState,
-    actions: SessionScreenActions,
-    webContent: @Composable () -> Unit,
+    onHomeClick: () -> Unit,
+    onBottomSheetValueChange: (ClipyBottomSheetValue) -> Unit,
     modifier: Modifier = Modifier,
+    webContent: @Composable () -> Unit,
 ) {
     // TODO: 디자인 시스템 적용
     Column(
         modifier = modifier.fillMaxSize(),
     ) {
         SessionHeader(
-            onHomeClick = actions.onHomeClick,
-        )
-        SessionBrowserToolbar(
-            state = state,
-            actions = actions,
+            onHomeClick = onHomeClick,
         )
         Box(
             modifier = Modifier
@@ -140,6 +131,23 @@ private fun SessionScreen(
                 .weight(1f),
         ) {
             webContent()
+            ClipyBottomSheetLayout(
+                value = state.bottomSheetState.toClipyBottomSheetValue(),
+                onValueChange = { bottomSheetValue ->
+                    onBottomSheetValueChange(bottomSheetValue)
+                },
+                modifier = Modifier,
+                headerContent = { contentValue ->
+                    SessionBottomSheetChrome(
+                        value = contentValue,
+                    )
+                },
+                sheetContent = { contentValue ->
+                    SessionBottomSheetContent(
+                        value = contentValue,
+                    )
+                },
+            )
         }
     }
 }
@@ -147,9 +155,10 @@ private fun SessionScreen(
 @Composable
 private fun SessionHeader(
     onHomeClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .height(50.dp)
             .background(MaterialTheme.colorScheme.background)
@@ -157,7 +166,7 @@ private fun SessionHeader(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        BrowserToolbarTextButton(
+        SessionHeaderTextButton(
             text = "홈",
             onClick = onHomeClick,
         )
@@ -169,66 +178,148 @@ private fun SessionHeader(
 }
 
 @Composable
-private fun SessionBrowserToolbar(
-    state: SessionUiState,
-    actions: SessionScreenActions,
+private fun SessionBottomSheetChrome(
+    value: ClipyBottomSheetValue,
     modifier: Modifier = Modifier,
 ) {
-    Row(
+    when (value) {
+        ClipyBottomSheetValue.MINIMIZED,
+        ClipyBottomSheetValue.PEEK,
+        -> {
+            Box(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp),
+            ) {
+                SessionBottomSheetUrlBar()
+            }
+        }
+
+        ClipyBottomSheetValue.HIDDEN,
+        ClipyBottomSheetValue.EXPANDED,
+        -> Unit
+    }
+}
+
+@Composable
+private fun SessionBottomSheetContent(
+    value: ClipyBottomSheetValue,
+    modifier: Modifier = Modifier,
+) {
+    Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 12.dp, vertical = 8.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalAlignment = Alignment.CenterVertically,
+            .padding(horizontal = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        BrowserToolbarTextButton(
-            text = "<",
-            enabled = state.canGoBack,
-            onClick = actions.onBackClick,
-        )
-        BrowserToolbarTextButton(
-            text = ">",
-            enabled = state.canGoForward,
-            onClick = actions.onForwardClick,
-        )
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(32.dp)
-                .background(
-                    color = Color.LightGray,
-                    shape = RoundedCornerShape(14.dp),
-                ),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Spacer(Modifier.width(12.dp))
-            Text(
-                text = state.currentUrl,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f),
+        when (value) {
+            ClipyBottomSheetValue.HIDDEN -> Unit
+            ClipyBottomSheetValue.MINIMIZED -> Unit
+            ClipyBottomSheetValue.PEEK -> SessionPeekPlaceholder(
+                modifier = Modifier.padding(top = 16.dp),
             )
-            BrowserToolbarTextButton(
-                text = "↻",
-                onClick = actions.onRefreshClick,
-            )
-            Spacer(Modifier.width(12.dp))
+
+            ClipyBottomSheetValue.EXPANDED -> SessionExpandedPlaceholder()
         }
     }
 }
 
 @Composable
-private fun BrowserToolbarTextButton(
+private fun SessionBottomSheetUrlBar(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(44.dp)
+            .background(
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = RoundedCornerShape(22.dp),
+            )
+            .padding(horizontal = 16.dp),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Text(
+            text = "Url Bar",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Composable
+private fun SessionPeekPlaceholder(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(128.dp)
+            .background(
+                color = MaterialTheme.colorScheme.secondaryContainer,
+                shape = RoundedCornerShape(20.dp),
+            )
+            .padding(20.dp),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Text(
+            text = "Items",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+    }
+}
+
+@Composable
+private fun SessionExpandedPlaceholder(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = "Session",
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        repeat(3) { index ->
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(64.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.surfaceVariant,
+                        shape = RoundedCornerShape(16.dp),
+                    )
+                    .padding(horizontal = 16.dp),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                Text(
+                    text = "Item ${index + 1}",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SessionHeaderTextButton(
     text: String,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
     enabled: Boolean = true,
 ) {
     Button(
         onClick = onClick,
         enabled = enabled,
-        modifier = Modifier
+        modifier = modifier
             .defaultMinSize(
                 minWidth = Dp.Hairline,
                 minHeight = Dp.Hairline,
@@ -263,22 +354,25 @@ private fun SessionScreenPreview() {
                 sessionId = "preview-session",
                 currentUrl = DEFAULT_HOME_URL,
             ),
-            actions = SessionScreenActions(
-                onHomeClick = { },
-                onBackClick = { },
-                onForwardClick = { },
-                onRefreshClick = { },
-            ),
-            webContent = {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.surface),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(text = "WebView")
-                }
-            },
-        )
+            onHomeClick = { },
+            onBottomSheetValueChange = { },
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.surface),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(text = "WebView")
+            }
+        }
     }
 }
+
+private fun BottomSheetState.toClipyBottomSheetValue(): ClipyBottomSheetValue =
+    when (this) {
+        BottomSheetState.HIDDEN -> ClipyBottomSheetValue.HIDDEN
+        BottomSheetState.MINIMIZED -> ClipyBottomSheetValue.MINIMIZED
+        BottomSheetState.PEEK -> ClipyBottomSheetValue.PEEK
+        BottomSheetState.EXPANDED -> ClipyBottomSheetValue.EXPANDED
+    }

--- a/feature/session/src/main/java/com/laxotters/clipy/feature/session/SessionScreen.kt
+++ b/feature/session/src/main/java/com/laxotters/clipy/feature/session/SessionScreen.kt
@@ -1,5 +1,6 @@
 package com.laxotters.clipy.feature.session
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -59,6 +60,12 @@ fun SessionRoute(
         )
     }
 
+    SessionBackHandler(
+        canGoBack = screenState.canGoBack,
+        onWebViewBack = webViewController::goBack,
+        onSessionExit = onHomeClick,
+    )
+
     SessionScreen(
         state = screenState,
         actions = SessionScreenActions(
@@ -85,6 +92,21 @@ fun SessionRoute(
         },
         modifier = modifier,
     )
+}
+
+@Composable
+private fun SessionBackHandler(
+    canGoBack: Boolean,
+    onWebViewBack: () -> Unit,
+    onSessionExit: () -> Unit,
+) {
+    BackHandler {
+        if (canGoBack) {
+            onWebViewBack()
+        } else {
+            onSessionExit()
+        }
+    }
 }
 
 private data class SessionScreenActions(

--- a/feature/session/src/main/java/com/laxotters/clipy/feature/session/SessionViewModel.kt
+++ b/feature/session/src/main/java/com/laxotters/clipy/feature/session/SessionViewModel.kt
@@ -9,7 +9,7 @@ class SessionViewModel @Inject constructor() :
     BaseViewModel<SessionUiState, SessionUiEvent, SessionUiSideEffect>(SessionUiState()) {
     override fun handleEvent(event: SessionUiEvent) {
         when (event) {
-            is SessionUiEvent.Entered -> updateState {
+            is SessionUiEvent.ScreenEntered -> updateState {
                 if (sessionId == event.sessionId && currentUrl.isNotBlank()) {
                     this
                 } else {
@@ -22,7 +22,7 @@ class SessionViewModel @Inject constructor() :
                 }
             }
 
-            is SessionUiEvent.WebPageStateChanged -> updateState {
+            is SessionUiEvent.PageLoaded -> updateState {
                 copy(
                     currentUrl = event.url,
                     canGoBack = event.canGoBack,

--- a/feature/session/src/main/java/com/laxotters/clipy/feature/session/SessionViewModel.kt
+++ b/feature/session/src/main/java/com/laxotters/clipy/feature/session/SessionViewModel.kt
@@ -1,6 +1,8 @@
 package com.laxotters.clipy.feature.session
 
+import com.laxotters.clipy.core.designsystem.component.ClipyBottomSheetValue
 import com.laxotters.clipy.core.ui.base.BaseViewModel
+import com.laxotters.clipy.domain.model.BottomSheetState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -18,6 +20,7 @@ class SessionViewModel @Inject constructor() :
                         currentUrl = event.initialUrl.ifBlank { DEFAULT_HOME_URL },
                         canGoBack = false,
                         canGoForward = false,
+                        bottomSheetState = BottomSheetState.PEEK,
                     )
                 }
             }
@@ -29,6 +32,18 @@ class SessionViewModel @Inject constructor() :
                     canGoForward = event.canGoForward,
                 )
             }
+
+            is SessionUiEvent.BottomSheetValueChanged -> updateState {
+                copy(bottomSheetState = event.value.toBottomSheetState())
+            }
         }
     }
 }
+
+private fun ClipyBottomSheetValue.toBottomSheetState(): BottomSheetState =
+    when (this) {
+        ClipyBottomSheetValue.HIDDEN -> BottomSheetState.HIDDEN
+        ClipyBottomSheetValue.MINIMIZED -> BottomSheetState.MINIMIZED
+        ClipyBottomSheetValue.PEEK -> BottomSheetState.PEEK
+        ClipyBottomSheetValue.EXPANDED -> BottomSheetState.EXPANDED
+    }

--- a/feature/session/src/test/java/com/laxotters/clipy/feature/session/SessionViewModelTest.kt
+++ b/feature/session/src/test/java/com/laxotters/clipy/feature/session/SessionViewModelTest.kt
@@ -1,0 +1,47 @@
+package com.laxotters.clipy.feature.session
+
+import com.laxotters.clipy.core.designsystem.component.ClipyBottomSheetValue
+import com.laxotters.clipy.domain.model.BottomSheetState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SessionViewModelTest {
+    @Test
+    fun initialState_createViewModel_hasPeekBottomSheetState() {
+        val viewModel = SessionViewModel()
+
+        assertEquals(BottomSheetState.PEEK, viewModel.state.value.bottomSheetState)
+    }
+
+    @Test
+    fun changedBottomSheetState_newSessionEntered_resetsBottomSheetStateToPeek() {
+        val viewModel = SessionViewModel()
+
+        viewModel.dispatch(SessionUiEvent.BottomSheetValueChanged(ClipyBottomSheetValue.EXPANDED))
+        viewModel.dispatch(
+            SessionUiEvent.ScreenEntered(
+                sessionId = "session-1",
+                initialUrl = "https://example.com",
+            ),
+        )
+
+        assertEquals(BottomSheetState.PEEK, viewModel.state.value.bottomSheetState)
+    }
+
+    @Test
+    fun bottomSheetValueChanged_dispatchEvent_updatesBottomSheetState() {
+        val viewModel = SessionViewModel()
+        val cases = listOf(
+            ClipyBottomSheetValue.HIDDEN to BottomSheetState.HIDDEN,
+            ClipyBottomSheetValue.MINIMIZED to BottomSheetState.MINIMIZED,
+            ClipyBottomSheetValue.PEEK to BottomSheetState.PEEK,
+            ClipyBottomSheetValue.EXPANDED to BottomSheetState.EXPANDED,
+        )
+
+        cases.forEach { (value, expectedState) ->
+            viewModel.dispatch(SessionUiEvent.BottomSheetValueChanged(value))
+
+            assertEquals(expectedState, viewModel.state.value.bottomSheetState)
+        }
+    }
+}


### PR DESCRIPTION
## 📋 개요

> Closes #13 
> Jira: CLIPY-45

- `core:designsystem`에 anchor 기반 4-state BottomSheet primitive를 추가했습니다.
- Session 화면에서 WebView 위에 BottomSheet layer를 배치하고, `SessionViewModel`이 BottomSheet 상태를 제어하도록 연결했습니다.

## 변경 배경

- Bottom Sheet는 `Hidden / Minimized / Peek / Expanded` 상태를 가집니다.
- `Hidden`은 화면 밖 상태이고, `Minimized / Peek / Expanded`는 drag 가능한 상태입니다.
- 기본 `ModalBottomSheet` / `BottomSheetScaffold`로는 Clipy의 4-state 전이와 `Hidden` 상태를 명확하게 표현하기 어렵습니다.

## 변경 내용

#### BottomSheet primitive 추가

`ClipyBottomSheetLayout`
- `HIDDEN / MINIMIZED / PEEK / EXPANDED` 4개 상태를 지원합니다.
- 부모 높이와 상태별 visible height로 anchor offsetY를 계산합니다.
- `headerContent`, `sheetContent` slot을 분리해 Session chrome과 상태별 content를 호출부에서 구성할 수 있게 했습니다.

`ClipyBottomSheetPolicy`
- drag 종료 후 이동할 상태와 content에 전달할 value를 결정합니다.
- 느린 drag는 release 위치와 retention band를 기준 판단하고, 빠른 drag는 방향에 따라 상위 / 하위 상태로 전이합니다.
- `MINIMIZED`에서 expanded anchor band까지 올리면 `EXPANDED`, 그 전에는 `PEEK`로 전이합니다.
- drag 중 offsetY를 갱신하고, drag 종료 후 target anchor까지 spring animation으로 settle합니다.

#### Session 상태 연결

`SessionViewModel`
- `SessionUiState.bottomSheetState`를 추가하고 초기값을 `PEEK`으로 설정했습니다.
- 새 session context에 진입하면 BottomSheet 상태를 `PEEK`으로 초기화합니다.
- BottomSheet callback은 `SessionViewModel` 이벤트로 전달해 `BottomSheetState`를 갱신합니다.

`SessionScreen`
- WebView 위에 BottomSheet layer를 배치했습니다.
- `MINIMIZED / PEEK`에서는 임시 URL bar chrome을 표시합니다.
- `PEEK / EXPANDED` content는 후속 실제 UI 연결 전까지 placeholder로 구성했습니다.

#### 테스트 / 문서

- BottomSheet anchor, drag 전이, content value 결정 정책을 단위 테스트로 검증했습니다.
- SessionViewModel의 BottomSheet 초기값, session 진입 초기화, 상태 변경 이벤트를 테스트했습니다.
- BottomSheet offsetY, anchor, drag / settle 책임을 KDoc과 주석으로 문서화했습니다.

## 구현 메모

- `core:designsystem`은 Session, domain, storage 상태를 알지 않습니다.
- `feature:session`이 `BottomSheetState`와 `ClipyBottomSheetValue` 사이의 변환을 담당합니다.
- 현재 anchor는 `ClipyBottomSheetDefaults`의 visible height 기준으로 계산합니다.
- state별 실제 content 측정 기반 anchor 전환은 후속 티켓에서 진행합니다.
- Android system back 정책은 BottomSheet 상태 축소, WebView history back, Session exit 순서를 함께 다뤄야 하므로 후속 티켓에서 진행합니다.
- WebView scroll 기반 chrome 전이, final content / state 연결은 후속 티켓에서 진행합니다.

## 검증

<!-- 실행한 검증만 체크합니다. 실행하지 못한 항목은 이유를 적습니다. -->

- [x] `./gradlew :core:designsystem:ktlintCheck :core:designsystem:detekt`
- [x] `./gradlew :core:designsystem:testDebugUnitTest`
- [x] `./gradlew :feature:session:ktlintCheck`
- [x] `./gradlew :feature:session:testDebugUnitTest`
- [x] 수동 확인:
  - [x] 4개 BottomSheet state preview 확인
  - [x] Session 화면에서 WebView 위 BottomSheet layer 표시 확인
  - [x] Hidden / Minimized / Peek / Expanded drag 전이 확인

## 문서

- 없음

## 실행 화면

| Fast fling 전이 | Drag release 전이 |
| --- | --- |
| <img width="250" alt="fling" src="https://github.com/user-attachments/assets/95306029-73e9-4910-811f-23a41f33769f" /> | <img width="250" alt="drag" src="https://github.com/user-attachments/assets/3a679c3e-46bd-4b0d-a105-47f16ea83431" /> 


## 참고자료

- 없음
